### PR TITLE
illegal token fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react + sinatra starter",
+  "name": "reactsinatrastarter",
   "version": "1.0.0",
   "description": "example sinatra-react app",
   "main": "index.js",


### PR DESCRIPTION
I get the following two errors (yarn & npm respectively) unless i remove whitespace from the package name: 

*YARN*
error react starter@1.0.0: Name contains illegal characters

*NPM*
npm ERR! Invalid name: "react starter"