### PR TITLE
FIX: sinatra deploy failing to find index.html

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,7 +1,7 @@
 require 'sinatra'
 configure { set :server, :puma }
 
-set :root, 'lib/app'
+set :root, 'app'
 
 get '/' do
   render :html, :index


### PR DESCRIPTION
else not working With Puma Version 3.11.2 and Sinatra 1.4.7
Please do check if it is the same with you @alanbsmith ..
And Thanks for this scaffold! :smile: 